### PR TITLE
DERP-246 - Update example content

### DIFF
--- a/modules/gla_core_example_content/content/node/8b2e275d-cf80-4809-aff5-1e7a4a40fcb7.yml
+++ b/modules/gla_core_example_content/content/node/8b2e275d-cf80-4809-aff5-1e7a4a40fcb7.yml
@@ -143,7 +143,7 @@ default:
               value: true
           field_p_rt_rich_text:
             -
-              value: "<p>Notice how the SlideShare embed below is a different size to the one above and is also missing the text below it? I think this is because it is a 'secret' (unlisted) SlideShare item, and presumably that affects how it is embedded. The embed code all comes from SlideShare so I don't know if this is something that we will be able to fix. However, I noticed that <a href=\"https://www.london.gov.uk/coronavirus/londons-recovery-coronavirus-crisis/recovering-coronavirus-it-begins-you\">the D7 site does not have this issue</a>, which complicates things a little!</p>\r\n"
+              value: "<p>Notice how the SlideShare embed below is a different size to the one above and is also missing the text below it? I think this is because it is a 'secret' (unlisted) SlideShare item, and that <a href=\"https://github.com/w8tcha/CKEditor-oEmbed-Plugin/issues/68\">prevents it being used with oEmbed</a>. I noticed that <a href=\"https://www.london.gov.uk/coronavirus/londons-recovery-coronavirus-crisis/recovering-coronavirus-it-begins-you\">the D7 site does not have this issue</a>, but I think that is because that SlideShare item is being embedded manually via copy-and-pasting HTML from SlideShare. To allow that on the D9 site we would need to go ahead with building the HTML widget&nbsp;component (<a href=\"https://london.atlassian.net/browse/DERP-236\">DERP-236</a>).</p>"
               format: full_html
     -
       entity:


### PR DESCRIPTION
Updated the example content to explain _why_ secret/unlisted SlideShares weren't embedding properly (because they don't support oEmbed) rather than just me saying 'this doesn't work but I'm not 100% sure why'.